### PR TITLE
[#4] Improves contributing guidance

### DIFF
--- a/contribute.rst
+++ b/contribute.rst
@@ -1,17 +1,21 @@
 Contributing
 ============
 
-We appreciate contributions to our open source projects.
+We appreciate all contributions to our open source projects. 
 
-We use GitHub issues to track our plans for our software. Feel free to volunteer to solve any of these.
+* We're interested in user experience and feedback from using the application.
+* We'd like people to fix bugs and contribute to features.
+* We're interested in people using the code for their own purposes.
+* We're interested in suggestions, modifications and improvements.
 
-BiteSize issues
+All our code can be found at https://github.com/IATI  
+
+Each project should have a specific ``CONTRIBUTING.rst`` file that gives more specific information about how to contribute to that particular project.
+
+Everything we are working on, or considering, is kept in GitHub issues. Feel free to contribute to any of these.
+
+Bitesize issues
 ^^^^^^^^^^^^^^^
+Getting started on someone else's software project can be daunting. So when we have an issue that we think would be a good task for someone new to the project, we mark them as  Bitesize.  
 
-We also have some issues marked as being easy to get started with - the ``Bitesize`` label.
-
-These currently exist for:
-
-* Dashboard - https://github.com/IATI/IATI-Dashboard/issues?labels=Bitesize&page=1&state=open
-* Validator - https://github.com/IATI/IATI-Public_Validator/issues?labels=Bitesize&page=1&state=open
-
+Look for issues marked with the `Bitesize <https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3AIATI+label%3ABitesize>`__ label if you want somewhere to start.


### PR DESCRIPTION
Adds a bit more detail. Gives a link to github!
Removes the link to individual projects and instead gives a link
to all bitesize issues
