### PR TITLE
Remove reference to python_dependency_pinning

### DIFF
--- a/code.rst
+++ b/code.rst
@@ -81,7 +81,7 @@ We use the following external services to test our code in various ways:
 
 * `Travis <https://travis-ci.org/>`__ - runs unit tests every time a commit is made
 * `Coveralls <https://coveralls.io/>`__ - checks the coverage of those unit tests
-* `Requires.io <https://requires.io>`__ (Python specific) - tests to see whether the Python moudles listed in requirements.txt are up to date (see :ref:`python_dependency_pinning` for more)
+* `Requires.io <https://requires.io>`__ (Python specific) - tests to see whether the Python moudles listed in requirements.txt are up to date
 * `Landscape <https://landscape.io/>`__ (Python specific) - calculates the quality of the code using static analysis, and tracks this over time
 
 A public link to the results of each of these service can be found at the top of the README of each covered project.

--- a/code.rst
+++ b/code.rst
@@ -81,7 +81,7 @@ We use the following external services to test our code in various ways:
 
 * `Travis <https://travis-ci.org/>`__ - runs unit tests every time a commit is made
 * `Coveralls <https://coveralls.io/>`__ - checks the coverage of those unit tests
-* `Requires.io <https://requires.io>`__ (Python specific) - tests to see whether the Python moudles listed in requirements.txt are up to date
+* `Requires.io <https://requires.io>`__ (Python specific) - tests to see whether the Python modules listed in requirements.txt are up to date
 * `Landscape <https://landscape.io/>`__ (Python specific) - calculates the quality of the code using static analysis, and tracks this over time
 
 A public link to the results of each of these service can be found at the top of the README of each covered project.


### PR DESCRIPTION
The [IATI Code page](http://iatistandard.org/203/developer/code/#external-testing-services) says:

>  * [Requires.io](https://requires.io/) (Python specific) - tests to see whether the Python moudles listed in requirements.txt are up to date (see _python_dependency_pinning_ for more)

This reference is broken, and I’m not sure what happened to the thing it referred to.