### PR TITLE
Fix publishing tools link

### DIFF
--- a/tools.rst
+++ b/tools.rst
@@ -6,7 +6,7 @@ The Open Development Toolkit project catalogues development related tools (altho
 * For more user facing tools, see http://www.opendevtoolkit.org/resources/online-iati-tools.html
 * For developer facing tools and utilities, see http://opendev.hackdash.org/
 
-If you are looking for tools to publish to IATI, see `</how-to-publish/select-publishing-tool/>`_
+If you are looking for tools to publish to IATI, see `<http://reference.iatistandard.org/how-to-publish/select-publishing-tool/>`_
 
 Other older sources of information:
 

--- a/tools.rst
+++ b/tools.rst
@@ -6,7 +6,7 @@ The Open Development Toolkit project catalogues development related tools (altho
 * For more user facing tools, see http://www.opendevtoolkit.org/resources/online-iati-tools.html
 * For developer facing tools and utilities, see http://opendev.hackdash.org/
 
-If you are looking for tools to publish to IATI, see http://iatistandard.org/how-to-publish/select-publishing-tool/
+If you are looking for tools to publish to IATI, see `</how-to-publish/select-publishing-tool/>`
 
 Other older sources of information:
 

--- a/tools.rst
+++ b/tools.rst
@@ -6,7 +6,7 @@ The Open Development Toolkit project catalogues development related tools (altho
 * For more user facing tools, see http://www.opendevtoolkit.org/resources/online-iati-tools.html
 * For developer facing tools and utilities, see http://opendev.hackdash.org/
 
-If you are looking for tools to publish to IATI, see `</how-to-publish/select-publishing-tool/>`
+If you are looking for tools to publish to IATI, see `</how-to-publish/select-publishing-tool/>`_
 
 Other older sources of information:
 


### PR DESCRIPTION
Replacing the URL so it's now using correct absolute URL for the reference site (thus fixing the broken redirect)