### PR TITLE
Fix broken links

### DIFF
--- a/codelist-api.rst
+++ b/codelist-api.rst
@@ -164,5 +164,5 @@ If you do this you may not need to alter the way you deal with codelists, but th
 * Version information is no longer provided in the XML.
 * Specific changes to codelists:
 
-  * The `BudgetIdentifier <https://github.com/orgs/IATI/teams>`__codelist has different categories, and no 'sector' elements.
+  * The `BudgetIdentifier <https://iatistandard.org/en/iati-standard/105/codelists/budgetidentifier/>`__ codelist has different categories, and no 'sector' elements.
   * Names in the `FileFormat <https://iatistandard.org/en/iati-standard/203/codelists/fileformat/>`__ codelist are no longer there as they make little sense, and the list now tracks the IANA source it is derived from directly.

--- a/codelist-api.rst
+++ b/codelist-api.rst
@@ -110,14 +110,14 @@ Working with GitHub Directly
 The codelist source is now on GitHub:
 
 Core (Previously Embedded) Codelists
-------------------
+------------------------------------
 As of version 1.04, each version of the standard has it's own branch in this repository. Branches are named version-<version-number> e.g. version-1.05.
 So, for example, the version 1.05 codelists can be found at:
 
 - https://github.com/IATI/IATI-Codelists/tree/version-1.05/xml
 
 Non-Core and Replicated (Previously Non-Embedded) Codelists
-----------------------
+-----------------------------------------------------------
 These values on these lists can change independently of IATI versions. The latest versions are always on the 'master' branch.
 
 - https://github.com/IATI/IATI-Codelists-NonEmbedded/tree/master/xml
@@ -164,5 +164,5 @@ If you do this you may not need to alter the way you deal with codelists, but th
 * Version information is no longer provided in the XML.
 * Specific changes to codelists:
 
-  * :doc:`/codelists/BudgetIdentifier/` has different categories, and no 'sector' elements.
-  * Names in the :doc:`/codelists/FileFormat/` list are no longer there as they make little sense, and the list now tracks the IANA source it is derived from directly.
+  * The `BudgetIdentifier <https://github.com/orgs/IATI/teams>`__codelist has different categories, and no 'sector' elements.
+  * Names in the the `FileFormat <https://iatistandard.org/en/iati-standard/203/codelists/fileformat/>`__ codelist are no longer there as they make little sense, and the list now tracks the IANA source it is derived from directly.

--- a/codelist-api.rst
+++ b/codelist-api.rst
@@ -165,4 +165,4 @@ If you do this you may not need to alter the way you deal with codelists, but th
 * Specific changes to codelists:
 
   * The `BudgetIdentifier <https://github.com/orgs/IATI/teams>`__codelist has different categories, and no 'sector' elements.
-  * Names in the the `FileFormat <https://iatistandard.org/en/iati-standard/203/codelists/fileformat/>`__ codelist are no longer there as they make little sense, and the list now tracks the IANA source it is derived from directly.
+  * Names in the `FileFormat <https://iatistandard.org/en/iati-standard/203/codelists/fileformat/>`__ codelist are no longer there as they make little sense, and the list now tracks the IANA source it is derived from directly.

--- a/old-datastore/reference/data-api.rst
+++ b/old-datastore/reference/data-api.rst
@@ -9,7 +9,7 @@ Available filters
 iati-identifier
 ```````````````
 
-Returns activities matching your specified `IATI Identifier <http://iatistandard.org/activity-standard/iati-identifier/>`__ value.  In practice, no more than one activity should be returned as each activity should contain a unique `IATI Identifier <http://iatistandard.org/activity-standard/iati-identifier/>`__ value.
+Returns activities matching your specified `IATI Identifier <https://iatistandard.org/en/iati-standard/203/activity-standard/iati-activities/iati-activity/iati-identifier/>`__ value.  In practice, no more than one activity should be returned as each activity should contain a unique `IATI Identifier <https://iatistandard.org/en/iati-standard/203/activity-standard/iati-activities/iati-activity/iati-identifier/>`__ value.
 
 Parameters:
   iati-identifier: String denoting an individual IATI activity ID
@@ -45,7 +45,7 @@ Example API call:
 reporting-org
 `````````````
 
-Returns activities where the `reporting-org <http://iatistandard.org/activity-standard/iati-activities/iati-activity/reporting-org/>`__ element has a @ref attribute value that matches your specified `Organisation identifier <http://iatistandard.org/organisation-identifiers/>`__ string.
+Returns activities where the `reporting-org <http://iatistandard.org/activity-standard/iati-activities/iati-activity/reporting-org/>`__ element has a @ref attribute value that matches your specified `Organisation identifier <https://iatistandard.org/en/iati-standard/203/activity-standard/iati-activities/iati-activity/reporting-org/>`__ string.
 
 Parameters:
     reporting-org: Organisation identifier string.
@@ -60,7 +60,7 @@ reporting-org.type
 Returns activities where the `reporting-org <http://iatistandard.org/activity-standard/iati-activities/iati-activity/reporting-org/>`__ element has a @type attribute value that matches your specified value.
 
 Parameters:
-    recipient-org.type: 2-digit value that appears on the `organisation type codelist<http://iatistandard.org/codelists/OrganisationType/>`__
+    recipient-org.type: 2-digit value that appears on the `organisation type codelist <http://iatistandard.org/codelists/OrganisationType/>`__
 
 Example API call:
     `reporting-org.type=10 <http://datastore.iatistandard.org/api/1/access/activity.xml?reporting-org.type=10>`__
@@ -84,7 +84,7 @@ policy-marker
 Returns activities where a `policy-marker <http://iatistandard.org/activity-standard/iati-activities/iati-activity/policy-marker/>`__ element has a @code attribute value that matches your specified policy-marker value.
 
 Parameters:
-    policy-marker: 1-digit value that appears on the `policy marker codelist<http://iatistandard.org/codelists/PolicyMarker/>`__
+    policy-marker: 1-digit value that appears on the `policy marker codelist <http://iatistandard.org/codelists/PolicyMarker/>`__
 
 Example API call:
     `policy-marker=1 <http://datastore.iatistandard.org/api/1/access/activity.xml?policy-marker=1>`__
@@ -93,7 +93,7 @@ Example API call:
 participating-org
 ``````````````````
 
-Returns activities where the `participating-org <http://iatistandard.org/activity-standard/iati-activities/iati-activity/reporting-org/>`__ element has a @ref attribute value that matches your specified participating-org identification string.
+Returns activities where the `participating-org <https://iatistandard.org/en/iati-standard/203/activity-standard/iati-activities/iati-activity/participating-org/>`__ element has a @ref attribute value that matches your specified participating-org identification string.
 
 Parameters:
     participating-org: Identification string for the organisation who is participating
@@ -144,7 +144,7 @@ transaction_provider-org
 Returns activities containing at least one `transaction element <http://iatistandard.org/activity-standard/iati-activities/iati-activity/transaction/>`__ where the provider-org element has a @ref attribute value that matches your specified organisation identifier string.
 
 Parameters:
-    transaction_provider-org: `Organisation identifier string <http://iatistandard.org/organisation-identifiers/>`__ for the organisation issuing who provided transaction funds
+    transaction_provider-org: `Organisation identifier string <https://iatistandard.org/en/iati-standard/203/activity-standard/iati-activities/iati-activity/transaction/provider-org/>`__ for the organisation issuing who provided transaction funds
 
 Example API call:
     `transaction_provider-org=GB-1 <http://datastore.iatistandard.org/api/1/access/activity.xml?transaction_provider-org=GB-1>`__
@@ -168,7 +168,7 @@ transaction_receiver-org
 Returns activities containing at least one `transaction element <http://iatistandard.org/activity-standard/iati-activities/iati-activity/transaction/>`__ where funds have been transferred to an organisation with your specified `Organisation identifier <http://iatistandard.org/organisation-identifiers/>`__ string.
 
 Parameters:
-    transaction_receiver-org: `Organisation identifier string <http://iatistandard.org/organisation-identifiers/>`__ for the organisation issuing who received transaction funds
+    transaction_receiver-org: `Organisation identifier string <https://iatistandard.org/en/iati-standard/203/activity-standard/iati-activities/iati-activity/transaction/receiver-org/>`__ for the organisation issuing who received transaction funds
 
 Example API call:
     `transaction_receiver-org=GB-CHC-1108464 <http://datastore.iatistandard.org/api/1/access/activity.xml?transaction_receiver-org=GB-CHC-1108464>`__


### PR DESCRIPTION
Fix broken links in Developer Documentation. Most caused by the migration to wagtail, others have been present for a long time.