### PR TITLE
Fix internal links

### DIFF
--- a/old-datastore/datastore.rst
+++ b/old-datastore/datastore.rst
@@ -1,13 +1,10 @@
 Datastore (Alpha)
 =================
 
-The Datastore stores all activity data available on the IATI Registry, allowing you to query it all in one place. This data can be accessed in spreadsheet format, or in more technical formats through a standard interface (API). Please be aware that this product is considered to be in alpha (`see below <http://iatistandard.org/guidance/datastore/#alpha-status>`__).
+The Datastore stores all activity data available on the IATI Registry, allowing you to query it all in one place. This data can be accessed in spreadsheet format, or in more technical formats through a standard interface (API). Please be aware that this product is considered to be in alpha (`see below <#alpha-status>`__).
 
-.. toctree::
-    :titlesonly:
-
-    datastore/guidance
-    datastore/reference
+* `Guidance <guidance.rst>`__
+* `Reference <reference.rst>`__
 
 IATI Datastore CSV Query Builder
 --------------------------------
@@ -19,9 +16,9 @@ Overview
 
 The Datastore has three APIs:
 
-* `Data API <http://iatistandard.org/guidance/datastore/reference/data-api/>`__: Allows you to make queries which can output IATI data in your chosen format (CSV, XML or JSON).
-* `Metadata API <http://iatistandard.org/guidance/datastore/reference/metadata-api/>`__: Allows you to find information about datasets that are contained within the Datastore.
-* `Error API <http://iatistandard.org/guidance/datastore/reference/error-api/>`__: Allows you to see information about datasets that could not be successfully imported into the Datastore.
+* `Data API <reference/data-api.rst>`__: Allows you to make queries which can output IATI data in your chosen format (CSV, XML or JSON).
+* `Metadata API <reference/metadata-api.rst>`__: Allows you to find information about datasets that are contained within the Datastore.
+* `Error API <reference/error-api.rst>`__: Allows you to see information about datasets that could not be successfully imported into the Datastore.
 
 Anyone can access the Datastore – just build a query and data will be returned.
 
@@ -61,5 +58,5 @@ Next Steps
 
 The Datastore can do much more than is shown here.
 
-* See the `Guidance <http://iatistandard.org/guidance/datastore/guidance/>`__ for a more detailed guide on querying the Datastore.
-* For in-depth documentation, see the `Reference <http://iatistandard.org/guidance/datastore/reference/>`__.
+* See the `Guidance <guidance.rst>`__ for a more detailed guide on querying the Datastore.
+* For in-depth documentation, see the `Reference <reference.rst>`__.

--- a/old-datastore/guidance.rst
+++ b/old-datastore/guidance.rst
@@ -3,7 +3,5 @@ Guidance
 
 The finer points of how to use the Datastore.
 
-.. toctree::
-
-    guidance/forming-queries
-    guidance/data-formats
+* `Forming Queries <guidance/forming-queries.rst>`__
+* `Data Formats <guidance/data-formats.rst>`__

--- a/old-datastore/guidance/data-formats.rst
+++ b/old-datastore/guidance/data-formats.rst
@@ -10,12 +10,12 @@ When outputting data in CSV format you can instead choose to display data based 
 XML
 ---
 
-The Datastore returns the original activity XML as published. This is `enhanced with metadata <http://iatistandard.org/guidance/datastore/reference/structure-of-data/>`__ specifying the version that individual activities were published at, as well as details of the query result.
+The Datastore returns the original activity XML as published. This is `enhanced with metadata <../reference/structure-of-data.rst>`__ specifying the version that individual activities were published at, as well as details of the query result.
 
 JSON
 ----
 
-The Datastore will convert the published XML to a JSON format. All of the originally published information is present in this alternative format. The same `metadata <http://iatistandard.org/guidance/datastore/reference/structure-of-data/>`__ that is given in the XML output is available in the JSON output.
+The Datastore will convert the published XML to a JSON format. All of the originally published information is present in this alternative format. The same `metadata <../reference/structure-of-data.rst>`__ that is given in the XML output is available in the JSON output.
 
 CSV
 ---

--- a/old-datastore/guidance/forming-queries.rst
+++ b/old-datastore/guidance/forming-queries.rst
@@ -1,7 +1,7 @@
 Forming Queries
 ===============
 
-You can query the Datastore by building queries from filters. The identified data can then be output in an `XML <http://iatistandard.org/guidance/datastore/guidance/data-formats/#xml>`__, `JSON <http://iatistandard.org/guidance/datastore/guidance/data-formats/#json>`__ or `CSV <http://iatistandard.org/guidance/datastore/guidance/data-formats/#csv>`__ format depending on your needs.
+You can query the Datastore by building queries from filters. The identified data can then be output in an `XML <data-formats.rst#xml>`__, `JSON <data-formats.rst#json>`__ or `CSV <data-formats.rst#csv>`__ format depending on your needs.
 
 Basic Query
 -----------
@@ -71,4 +71,4 @@ You can return all activities, no matter how many there are, by adding `&stream=
 More Information
 ----------------
 
-For in-depth detail of all the available filters, see the `Reference <http://iatistandard.org/guidance/datastore/reference/data-api/>`__.
+For in-depth detail of all the available filters, see the `Reference <../reference/data-api.rst>`__.

--- a/old-datastore/reference.rst
+++ b/old-datastore/reference.rst
@@ -3,11 +3,7 @@ Reference
 
 In-depth documentation on everything the Datastore can do.
 
-.. toctree::
-    :titlesonly:
-
-    reference/data-api
-    reference/structure-of-data
-    reference/metadata-api
-    reference/error-api
-
+* `Data API <reference/data-api.rst>`__
+* `Structure of data <reference/structure-of-data.rst>`__
+* `Metadata API <reference/metadata-api.rst>`__
+* `Error API <reference/error-api.rst>`__

--- a/old-datastore/reference/structure-of-data.rst
+++ b/old-datastore/reference/structure-of-data.rst
@@ -8,8 +8,8 @@ The following information is given in the metadata for your query:
 * **generated-datetime**: This shows the time the query was run.
 * **ok**: This returns True when a query is successful.
 * **total-count**: This shows the number of activities that match your query.
-* **limit**: This shows the maximum number of activities you will see per page (see `Pagination <http://iatistandard.org/guidance/datastore/guidance/forming-queries/#pagination>`__).
-* **start**: This refers to the offset value (see `Pagination <http://iatistandard.org/guidance/datastore/guidance/forming-queries/#pagination>`__).
+* **limit**: This shows the maximum number of activities you will see per page (see `Pagination <../guidance/forming-queries.rst#pagination>`__).
+* **start**: This refers to the offset value (see `Pagination <../guidance/forming-queries.rst#pagination>`__).
 * **iati-extra: [version]**: This shows the version of the IATI standard for each returned activity. Activities returned will not necessarily be at the same version.
 
 XML


### PR DESCRIPTION
Given datastore docs are now to be hosted directly on github (not github pages or elsewhere), this PR fixes broken internal links.

Addresses [this comment on discuss](https://discuss.iatistandard.org/t/moving-iati-standard-content-from-iati-reference-site-to-main-iati-website/1987/12).